### PR TITLE
Pin pytensor version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
 	cython
 	cobra
 	swiglpk
+ 	pytensor==5.9.2
 	pymc
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,8 +58,7 @@ install_requires =
 	cython
 	cobra
 	swiglpk
- 	pytensor==5.9.2
-	pymc
+	pymc==5.9.2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Addresses #13 

Pinning a stable version of `PyMC` that works with `emll`. Newer versions of `PyMC` rely on newer versions of `PyTensor` that introduce incompatibilities. 

We pin `pymc==5.9.2` in the `setup.cfg`, until we can debug the compatibility issues with newer versions of `PyTensor`.