### PR TITLE
19 create pytensor rvs from missing datasets

### DIFF
--- a/src/emll/data_model_integration.py
+++ b/src/emll/data_model_integration.py
@@ -58,3 +58,31 @@ def create_noisy_observations_of_computed_values(name:str, computed_tensor:T.ten
                                              sigma=stdev_value,
                                              observed=observed_data)
     return rv
+
+
+def create_pytensor_from_data(name:str, data:pd.DataFrame)->T.tensor:  # noqa: D417
+    """"""
+
+    # Check input types
+    if not isinstance(name, str):
+        raise TypeError(f"Expected name to be of type {str.__name__}, but got {type(str).__name__} instead.")
+    
+    if not isinstance(data, pd.DataFrame):
+        raise TypeError(f"Expected data to be of type {pd.DataFrame.__name__}, but got {type(data).__name__} instead.")
+
+    # Function to check if a value is finite, np.nan, or np.inf
+    def check_value(x):
+        if isinstance(x, (int, float)):
+            return np.isfinite(x) or np.isnan(x) or np.isinf(x)
+        else:
+            return False
+
+    # Check that all values in the DataFrame are finite, np.nan, or np.inf
+    if not data.map(check_value).all().all():
+        raise ValueError("DataFrame contains values that are not finite, np.nan, or np.inf.")
+    
+    try:
+        model_context = pm.Model.get_context()
+    except TypeError as e:
+        raise TypeError("Function must be run within a PyMC model context.") from e
+

--- a/src/emll/data_model_integration.py
+++ b/src/emll/data_model_integration.py
@@ -39,6 +39,7 @@ def create_noisy_observations_of_computed_values(name:str, computed_tensor:T.ten
     if not data.columns.equals(estimated_stdev.columns):
         raise ValueError("Data and estimated standard deviations column labels are different.")
 
+    # check that model context exists
     try:
         model_context = pm.Model.get_context()
     except TypeError as e:
@@ -60,8 +61,23 @@ def create_noisy_observations_of_computed_values(name:str, computed_tensor:T.ten
     return rv
 
 
-def create_pytensor_from_data(name:str, data:pd.DataFrame)->T.tensor:  # noqa: D417
-    """"""
+def create_pytensor_from_data(name:str, data:pd.DataFrame, normal_stdev:pd.DataFrame, laplace_loc_and_scale:pd.date_range)->T.tensor:  # noqa: D417
+    """Creates a pytensor from data with missing values. 
+
+    Args:
+        name (str): Name to use for random variables (i.e., {name}_{row}_{col}).
+        data (pd.DataFrame): Data with rows = n conditions, columns = m model variables. 
+        Each value must be np.finite for observed, np.inf for unobserved, np.nan for excluded.
+        normal_stdev (pd.DataFrame): Standard deviations to use for observed data. 
+        Each value must be either np.nan or positive np.finite, and the dataframe must have the 
+        same shape as the data.
+        laplace_loc_and_scale (pd.date_range): Laplace location (mu) and scale (b) parameters for 
+        unobserved variables. Each value must be either a tuple (mu,b) or np.nan, with mu np.finite
+        and b positive finite, and dataframe must have the same shape as the data. 
+
+    Returns:
+        T.tensor: Stacked pytensor of normal dist, laplace dist, and zeros.
+    """
 
     # Check input types
     if not isinstance(name, str):
@@ -70,19 +86,112 @@ def create_pytensor_from_data(name:str, data:pd.DataFrame)->T.tensor:  # noqa: D
     if not isinstance(data, pd.DataFrame):
         raise TypeError(f"Expected data to be of type {pd.DataFrame.__name__}, but got {type(data).__name__} instead.")
 
-    # Function to check if a value is finite, np.nan, or np.inf
-    def check_value(x):
+    if not isinstance(normal_stdev, pd.DataFrame):
+        raise TypeError(f"Expected normal_stdev to be of type {pd.DataFrame.__name__}, but got {type(normal_stdev).__name__} instead.")
+
+    if not isinstance(laplace_loc_and_scale, pd.DataFrame):
+        raise TypeError(f"Expected laplace_loc_and_scale to be of type {pd.DataFrame.__name__}, but got {type(laplace_loc_and_scale).__name__} instead.")
+
+
+    # Check input shapes match
+    if data.shape != normal_stdev.shape:
+            raise ValueError(f"Data shape {data.shape} does not match the standard deviation shape {normal_stdev.shape}!")
+
+    if data.shape != laplace_loc_and_scale.shape:
+            raise ValueError(f"Data shape {data.shape} does not match the laplace loc and scale shape {laplace_loc_and_scale.shape}!")
+
+    # Function to check if the data value is finite, np.nan, or np.inf
+    def check_data_value(x):
         if isinstance(x, (int, float)):
             return np.isfinite(x) or np.isnan(x) or np.isinf(x)
         else:
             return False
 
-    # Check that all values in the DataFrame are finite, np.nan, or np.inf
-    if not data.map(check_value).all().all():
+    # Function to check if the stdev value is np.nan or finite > 0.
+    def check_stdev_value(x):
+        # Check if x is a number (either int or float)
+        if isinstance(x, (int, float)):
+            # Check if it's np.nan
+            if np.isnan(x):
+                return True
+            # Check for finite numbers > 0
+            return np.isfinite(x) and x > 0
+        # If it's not a number, return False
+        return False
+    
+    def check_laplace_value(x):
+        if isinstance(x, tuple):
+            # Check that the tuple has only two items
+            if len(x) != 2:
+                return False
+            # Check that the first item is finite
+            if not np.isfinite(x[0]):
+                return False
+            # Check that the second item is positive and finite
+            if not (np.isfinite(x[1]) and x[1] > 0):
+                return False
+            return True
+        elif pd.isna(x):
+            # The value is np.nan
+            return True
+        else:
+            # The value is something else
+            return False
+    
+    # Check that all values in the data DataFrame are finite, np.nan, or np.inf
+    if not data.map(check_data_value).all().all():
         raise ValueError("DataFrame contains values that are not finite, np.nan, or np.inf.")
     
+    # Check that all values in the stdev DataFrame are nan or finite > 0
+    if not normal_stdev.map(check_stdev_value).all().all():
+        raise ValueError("Stdev DataFrame contains invalid values. Valid values are np.nan or finite numbers > 0.")
+   
+    # Check that all values in the laplace DataFrame are tuple(finite, postive finite) or np.nan
+    if not laplace_loc_and_scale.map(check_laplace_value).all().all():
+        raise ValueError("Laplace DataFrame contains invalid values that are not tuple(finite, postive finite) or np.nan")
+
+    # Check that the columns are the same for data and standard deviation
+    if not data.columns.equals(normal_stdev.columns):
+        raise ValueError("Data and standard deviations column labels are different.")
+
+    # check that data and stdev rows match
+    if not data.index.equals(normal_stdev.index):
+        raise ValueError("The indices of data and standard deviation do not match.")
+    
+    # Check that the columns are the same for data and laplace
+    if not data.columns.equals(laplace_loc_and_scale.columns):
+        raise ValueError("Data and laplace column labels are different.")
+
+    # Check that the rows are the same for data and laplace
+    if not data.index.equals(laplace_loc_and_scale.index):
+        raise ValueError("Data and laplace indices are different.")
+
+
+    # check that model context exists
     try:
         model_context = pm.Model.get_context()
     except TypeError as e:
         raise TypeError("Function must be run within a PyMC model context.") from e
 
+    tensor_elements = []
+    for i, row in enumerate(data.index):
+        row_elements = []
+        for j, col in enumerate(data.columns):
+            data_value = data.loc[row,col]
+            if np.isfinite(data_value):  
+                # finite --> observed model variable --> Normal(log(variable value), 0.2)
+                sigma_value = normal_stdev.loc[row,col]
+                rv = pm.Normal.dist(name=f'{name}_{row}_{col}', mu=data_value, sigma=sigma_value)
+                row_elements.append(rv)
+            elif np.isinf(data_value):
+                # Inf --> unobserved model variable --> Laplace(loc,scale)
+                loc_value = laplace_loc_and_scale.loc[row,col][0]
+                scale_value = laplace_loc_and_scale.loc[row,col][1]
+                rv = pm.Laplace.dist(name=f'{name}_{row}_{col}', mu=loc_value, b=scale_value)
+                row_elements.append(rv)
+            elif np.isnan(data_value):
+                # Nan --> model variable is zero (excluded)
+                row_elements.append(T.zeros(1))
+        tensor_elements.append(row_elements)
+    data_tensor = T.stacklists(tensor_elements)
+    return data_tensor

--- a/src/emll/data_model_integration.py
+++ b/src/emll/data_model_integration.py
@@ -181,13 +181,13 @@ def create_pytensor_from_data(name:str, data:pd.DataFrame, normal_stdev:pd.DataF
             if np.isfinite(data_value):  
                 # finite --> observed model variable --> Normal(log(variable value), 0.2)
                 sigma_value = normal_stdev.loc[row,col]
-                rv = pm.Normal.dist(name=f'{name}_{row}_{col}', mu=data_value, sigma=sigma_value)
+                rv = pm.Normal.dist(name=f'{name}_{row}_{col}', mu=data_value, sigma=sigma_value, shape=(1,))
                 row_elements.append(rv)
             elif np.isinf(data_value):
                 # Inf --> unobserved model variable --> Laplace(loc,scale)
                 loc_value = laplace_loc_and_scale.loc[row,col][0]
                 scale_value = laplace_loc_and_scale.loc[row,col][1]
-                rv = pm.Laplace.dist(name=f'{name}_{row}_{col}', mu=loc_value, b=scale_value)
+                rv = pm.Laplace.dist(name=f'{name}_{row}_{col}', mu=loc_value, b=scale_value, shape=(1,))
                 row_elements.append(rv)
             elif np.isnan(data_value):
                 # Nan --> model variable is zero (excluded)

--- a/tests/test_data_model_integration.py
+++ b/tests/test_data_model_integration.py
@@ -1,4 +1,6 @@
+import pytensor.tensor
 from emll.data_model_integration import create_noisy_observations_of_computed_values
+from emll.data_model_integration import create_pytensor_from_data
 import pytest 
 import pytensor
 import numpy as np
@@ -90,3 +92,62 @@ def test_create_noisy_observations_of_computed_values():
             assert actual_stdev == expected_stdev
 
 
+def test_create_pytensor_from_data():
+
+    # setup input name and data
+    input_string = 'test'
+    input_data_dict_mixed = {
+        'x': [1.0, np.inf, np.nan],
+        'y': [np.inf, np.nan, 2]
+    }
+    input_data_dict_all_observed = {
+        'x': [1.0, 10.0, 100.0],
+        'y': [-5, -25, -125]
+    }
+    input_dataframe_mixed = pd.DataFrame(input_data_dict_mixed)
+    input_dataframe_all_observed = pd.DataFrame(input_data_dict_all_observed)
+
+    # setup "wrong" inputs for error handling checks
+    input_string_wrong_type= 42
+    input_data_dict_mixed_wrong_type = {
+        'x': [1.0, np.inf, None],
+        'y': ["test", np.nan, 2]
+    }
+    input_dataframe_mixed_wrong_type = pd.DataFrame(input_data_dict_mixed_wrong_type)
+
+    # check if type error is raised if name is not a string
+    with pytest.raises(TypeError):
+        create_pytensor_from_data(input_string_wrong_type,input_dataframe_mixed)
+    
+    # check if type error is raised if data is not a dataframe
+    with pytest.raises(TypeError):
+        create_pytensor_from_data(input_string,input_data_dict_mixed)
+
+    # check that value error is raised if data values are not finite, np.inf, or np.nan
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_mixed_wrong_type)
+
+    # check that type error is raised if not run in model context
+    with pytest.raises(TypeError):
+        create_pytensor_from_data(input_string,input_dataframe_mixed)
+
+
+    test_model = pm.Model()
+    with test_model:
+        
+        # check if actual returned value matches expected value 
+        # case 1: all data is observed across all conditions
+        # expect a normal distribution to be returned
+            rv_tensor = create_pytensor_from_data(input_string,input_dataframe_all_observed)
+        
+
+    #     # check if returned value is a pytensor
+    #     assert(type(create_pytensor_from_data(input_string,input_dataframe_mixed))==pytensor.tensor.TensorType)
+    
+
+    
+    # check rows and columns
+
+    # check if value error is raised if 
+    #input_data_values = 1
+    #raise NotImplementedError

--- a/tests/test_data_model_integration.py
+++ b/tests/test_data_model_integration.py
@@ -252,7 +252,7 @@ def test_create_pytensor_from_data():
     test_model = pm.Model()
     with test_model:
         data_tensor = create_pytensor_from_data(input_string,input_dataframe_no_observed,input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
-        
+        print(pytensor.dprint(data_tensor))
         # traverse the computational graph to get only the random variables
         ancestor_nodes = ancestors([data_tensor])
         apply_nodes = [node for node in ancestor_nodes if isinstance(node, TensorVariable) and node.owner is not None]
@@ -284,12 +284,23 @@ def test_create_pytensor_from_data():
 
     # Test case 3: all model variables are excluded for all conditions
     # All data should be np.nan with Normal and Laplace distributions not used
-    # input_data_dict_all_excluded = {
-    #     'x': [np.nan, np.nan, np.nan],
-    #     'y': [np.nan, np.nan, np.nan]
-    # }
-    # input_dataframe_all_excluded = pd.DataFrame(input_data_dict_all_excluded)
-    
+    input_data_dict_all_excluded = {
+        'x': [np.nan, np.nan, np.nan],
+        'y': [np.nan, np.nan, np.nan]
+    }
+    input_dataframe_all_excluded = pd.DataFrame(input_data_dict_all_excluded)
+
+    test_model = pm.Model()
+    with test_model:
+        data_tensor = create_pytensor_from_data(input_string, input_dataframe_all_excluded, input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
+
+        # check the actual number of zeros is the same as expected
+        tensor_values = data_tensor.eval()
+        actual_num_zeros = np.sum(tensor_values == 0)
+        expected_num_zeros = np.prod(input_dataframe_all_excluded.shape)
+        assert actual_num_zeros == expected_num_zeros, f"Expected {expected_num_zeros} zeroes, found {actual_num_zeros}"
+
+        
 
         # # test case 4: variables are a mixture of observed, unobserved, and excluded for all conditions
     # input_data_dict_mixed = {

--- a/tests/test_data_model_integration.py
+++ b/tests/test_data_model_integration.py
@@ -1,6 +1,8 @@
 
 from emll.data_model_integration import create_noisy_observations_of_computed_values
-from emll.data_model_integration import create_pytensor_from_data
+from emll.data_model_integration import create_pytensor_from_data_naive
+import emll
+
 import pytest 
 import pytensor
 import numpy as np
@@ -123,29 +125,29 @@ def test_create_pytensor_from_data():
     # check if type error is raised if name is not a string
     input_string_wrong_type = 42
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string_wrong_type,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string_wrong_type,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
     
     # check if type error is raised if data is not a dataframe
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_data_dict_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_data_dict_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
 
     # check if type error is raised if the stdev is not a dataframe
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dict_all_observed, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dict_all_observed, input_laplace_dataframe_no_observed)
 
     # check if type error is raised if the laplace is not a dataframe
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dict_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dict_no_observed)
 
     # check if value error is raised if the shape of the data and stdev dataframes aren't equal
     input_stdev_dataframe_fewer_columns = input_stdev_dataframe_all_observed.drop(columns='x').copy(deep=True)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_fewer_columns, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_fewer_columns, input_laplace_dataframe_no_observed)
 
     # check if value error is raised if the shape of the data and laplace dataframes aren't equal
     input_laplace_dataframe_fewer_columns = input_laplace_dataframe_no_observed.drop(columns='x').copy(deep=True)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_fewer_columns)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_fewer_columns)
 
     # check if value error is raised if data values are not finite, np.inf, or np.nan
     input_data_dict_wrong_values = {
@@ -154,12 +156,12 @@ def test_create_pytensor_from_data():
     }
     input_dataframe_wrong_values = pd.DataFrame(input_data_dict_wrong_values)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_wrong_values,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_wrong_values,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
 
     # check that a value error is raised if stdev values are not None or finite > 0
     input_stdev_dataframe_wrong_values = input_dataframe_wrong_values.copy(deep=True)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_values, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_values, input_laplace_dataframe_no_observed)
 
     # check if value error is raised if the laplace dataframe values are not a (finite, postive finite) or np.nan
     input_laplace_dict_wrong_values = {
@@ -168,31 +170,31 @@ def test_create_pytensor_from_data():
     }
     input_laplace_dataframe_wrong_values = pd.DataFrame(input_laplace_dict_wrong_values)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_values)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_values)
 
     # check that a value error is raised if the stdev columns don't match the data
     input_stdev_dataframe_wrong_cols = input_stdev_dataframe_all_observed.copy(deep=True).rename(columns={'x': 'z'})
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_cols, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_cols, input_laplace_dataframe_no_observed)
 
     # check that a value error is raised if the stdev rows don't match the data
     input_stdev_dataframe_renamed_index = input_stdev_dataframe_all_observed.copy(deep=True).rename(index={i: f'row{i+1}' for i in range(len(input_stdev_dataframe_all_observed))})
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_renamed_index, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_renamed_index, input_laplace_dataframe_no_observed)
 
     # check that a value error is raised if the laplace columns don't match the data
     input_laplace_dataframe_wrong_cols = input_laplace_dataframe_no_observed.copy(deep=True).rename(columns={'x': 'z'})
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_cols)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_cols)
 
     # check that a value error is raised if the laplace rows don't match the data
     input_laplace_dataframe_renamed_index = input_laplace_dataframe_no_observed.copy(deep=True).rename(index={i: f'row{i+1}' for i in range(len(input_laplace_dataframe_no_observed))})
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_renamed_index)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_renamed_index)
     
     # check that type error is raised if not run in model context
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
+        create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
 
 
     ### check actual outputs match expected outputs ###
@@ -206,7 +208,7 @@ def test_create_pytensor_from_data():
     input_laplace_dataframe_all_observed = pd.DataFrame(input_laplace_dict_all_observed)
     test_model = pm.Model()
     with test_model:
-        data_tensor = create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_all_observed)
+        data_tensor = create_pytensor_from_data_naive(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_all_observed)
         
         # traverse the computational graph to get only the random variables
         ancestor_nodes = ancestors([data_tensor])
@@ -251,7 +253,7 @@ def test_create_pytensor_from_data():
 
     test_model = pm.Model()
     with test_model:
-        data_tensor = create_pytensor_from_data(input_string,input_dataframe_no_observed,input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
+        data_tensor = create_pytensor_from_data_naive(input_string,input_dataframe_no_observed,input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
         
         # traverse the computational graph to get only the random variables
         ancestor_nodes = ancestors([data_tensor])
@@ -292,7 +294,7 @@ def test_create_pytensor_from_data():
 
     test_model = pm.Model()
     with test_model:
-        data_tensor = create_pytensor_from_data(input_string, input_dataframe_all_excluded, input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
+        data_tensor = create_pytensor_from_data_naive(input_string, input_dataframe_all_excluded, input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
 
         # check the actual number of zeros is the same as expected
         tensor_values = data_tensor.eval()
@@ -321,8 +323,7 @@ def test_create_pytensor_from_data():
 
     test_model = pm.Model()
     with test_model:
-        data_tensor = create_pytensor_from_data(input_string, input_dataframe_mixed, input_stdev_dataframe_mixed, input_laplace_dataframe_mixed)
-        print(pytensor.dprint(data_tensor))
+        data_tensor = create_pytensor_from_data_naive(input_string, input_dataframe_mixed, input_stdev_dataframe_mixed, input_laplace_dataframe_mixed)
 
         # Traverse the computational graph to get only the random variables
         ancestor_nodes = ancestors([data_tensor])
@@ -389,3 +390,14 @@ def test_create_pytensor_from_data():
         assert num_normal == expected_num_normal, f"Expected {expected_num_normal} normal RVs, found {num_normal}"
         assert num_laplace == expected_num_laplace, f"Expected {expected_num_laplace} Laplace RVs, found {num_laplace}"
         assert actual_num_zeros == expected_num_zeros, f"Expected {expected_num_zeros} zeros, found {actual_num_zeros}"
+
+    # check if output can be used by ll.steady_state_pytensor
+    test_model = pm.Model()
+    with test_model:
+        data_tensor = create_pytensor_from_data_naive(input_string, input_dataframe_mixed, input_stdev_dataframe_mixed, input_laplace_dataframe_mixed)
+
+        # check that the n-dim and shape are correct
+        assert np.size(data_tensor.shape.eval()) == np.size(input_dataframe_mixed.shape), f"Expected tensor n dim {np.size(input_dataframe_mixed.shape)}, found {np.size(data_tensor.shape.eval())}"
+        assert tuple(data_tensor.shape.eval()) == input_dataframe_mixed.shape, f"Expected tensor shape {input_dataframe_mixed.shape}, found {data_tensor.shape.eval()}"
+
+        

--- a/tests/test_data_model_integration.py
+++ b/tests/test_data_model_integration.py
@@ -1,4 +1,4 @@
-import pytensor.tensor
+
 from emll.data_model_integration import create_noisy_observations_of_computed_values
 from emll.data_model_integration import create_pytensor_from_data
 import pytest 
@@ -6,6 +6,12 @@ import pytensor
 import numpy as np
 import pandas as pd
 import pymc as pm
+
+from pytensor.graph.basic import ancestors
+from pytensor.tensor.variable import TensorVariable
+from pytensor.tensor.random.op import RandomVariable 
+
+
 
 def test_create_noisy_observations_of_computed_values():
     """Tests the create_noisy_observations_of_computed_values function."""
@@ -93,61 +99,206 @@ def test_create_noisy_observations_of_computed_values():
 
 
 def test_create_pytensor_from_data():
-
-    # setup input name and data
+    """Tests the create_pytensor_from_data function."""
+    ### setup initial fixtures ###
     input_string = 'test'
-    input_data_dict_mixed = {
-        'x': [1.0, np.inf, np.nan],
-        'y': [np.inf, np.nan, 2]
-    }
     input_data_dict_all_observed = {
         'x': [1.0, 10.0, 100.0],
         'y': [-5, -25, -125]
     }
-    input_dataframe_mixed = pd.DataFrame(input_data_dict_mixed)
     input_dataframe_all_observed = pd.DataFrame(input_data_dict_all_observed)
-
-    # setup "wrong" inputs for error handling checks
-    input_string_wrong_type= 42
-    input_data_dict_mixed_wrong_type = {
-        'x': [1.0, np.inf, None],
-        'y': ["test", np.nan, 2]
+    input_stdev_dict_all_observed = {
+        'x': [0.25, 2.5, 25],
+        'y': [1, 2, 4]
     }
-    input_dataframe_mixed_wrong_type = pd.DataFrame(input_data_dict_mixed_wrong_type)
+    input_stdev_dataframe_all_observed = pd.DataFrame(input_stdev_dict_all_observed)
 
+    input_laplace_dict_no_observed = {
+        'x': [(0, 1), (10, 0.5), (100, 0.25)],
+        'y': [(-0.5, 4), (-0.25, 2), (-0.125, 1)]
+    }
+    input_laplace_dataframe_no_observed = pd.DataFrame(input_laplace_dict_no_observed)
+
+    ### check that errors are caught from incorrect inputs ###
     # check if type error is raised if name is not a string
+    input_string_wrong_type = 42
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string_wrong_type,input_dataframe_mixed)
+        create_pytensor_from_data(input_string_wrong_type,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
     
     # check if type error is raised if data is not a dataframe
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_data_dict_mixed)
+        create_pytensor_from_data(input_string,input_data_dict_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
 
-    # check that value error is raised if data values are not finite, np.inf, or np.nan
+    # check if type error is raised if the stdev is not a dataframe
+    with pytest.raises(TypeError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dict_all_observed, input_laplace_dataframe_no_observed)
+
+    # check if type error is raised if the laplace is not a dataframe
+    with pytest.raises(TypeError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dict_no_observed)
+
+    # check if value error is raised if the shape of the data and stdev dataframes aren't equal
+    input_stdev_dataframe_fewer_columns = input_stdev_dataframe_all_observed.drop(columns='x').copy(deep=True)
     with pytest.raises(ValueError):
-        create_pytensor_from_data(input_string,input_dataframe_mixed_wrong_type)
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_fewer_columns, input_laplace_dataframe_no_observed)
 
+    # check if value error is raised if the shape of the data and laplace dataframes aren't equal
+    input_laplace_dataframe_fewer_columns = input_laplace_dataframe_no_observed.drop(columns='x').copy(deep=True)
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_fewer_columns)
+
+    # check if value error is raised if data values are not finite, np.inf, or np.nan
+    input_data_dict_wrong_values = {
+        'x': [1.0, np.inf, None],
+        'y': ["test", np.nan, -2]
+    }
+    input_dataframe_wrong_values = pd.DataFrame(input_data_dict_wrong_values)
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_wrong_values,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
+
+    # check that a value error is raised if stdev values are not None or finite > 0
+    input_stdev_dataframe_wrong_values = input_dataframe_wrong_values.copy(deep=True)
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_values, input_laplace_dataframe_no_observed)
+
+    # check if value error is raised if the laplace dataframe values are not a (finite, postive finite) or np.nan
+    input_laplace_dict_wrong_values = {
+        'x': [(0, 1), (10, 0.5, 2.5), "test"],
+        'y': [np.inf, (-0.25, 2), np.nan]
+    }
+    input_laplace_dataframe_wrong_values = pd.DataFrame(input_laplace_dict_wrong_values)
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_values)
+
+    # check that a value error is raised if the stdev columns don't match the data
+    input_stdev_dataframe_wrong_cols = input_stdev_dataframe_all_observed.copy(deep=True).rename(columns={'x': 'z'})
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_wrong_cols, input_laplace_dataframe_no_observed)
+
+    # check that a value error is raised if the stdev rows don't match the data
+    input_stdev_dataframe_renamed_index = input_stdev_dataframe_all_observed.copy(deep=True).rename(index={i: f'row{i+1}' for i in range(len(input_stdev_dataframe_all_observed))})
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_renamed_index, input_laplace_dataframe_no_observed)
+
+    # check that a value error is raised if the laplace columns don't match the data
+    input_laplace_dataframe_wrong_cols = input_laplace_dataframe_no_observed.copy(deep=True).rename(columns={'x': 'z'})
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_wrong_cols)
+
+    # check that a value error is raised if the laplace rows don't match the data
+    input_laplace_dataframe_renamed_index = input_laplace_dataframe_no_observed.copy(deep=True).rename(index={i: f'row{i+1}' for i in range(len(input_laplace_dataframe_no_observed))})
+    with pytest.raises(ValueError):
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_renamed_index)
+    
     # check that type error is raised if not run in model context
     with pytest.raises(TypeError):
-        create_pytensor_from_data(input_string,input_dataframe_mixed)
+        create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_no_observed)
 
+
+    ### check actual outputs match expected outputs ###
+
+    # Test case 1: all model variables are observed for all conditions
+    # Laplace values aren't used if all variables are observed
+    input_laplace_dict_all_observed = {
+        'x': [np.nan, np.nan, np.nan],
+        'y': [np.nan, np.nan, np.nan]
+    }
+    input_laplace_dataframe_all_observed = pd.DataFrame(input_laplace_dict_all_observed)
+    test_model = pm.Model()
+    with test_model:
+        data_tensor = create_pytensor_from_data(input_string,input_dataframe_all_observed,input_stdev_dataframe_all_observed, input_laplace_dataframe_all_observed)
+        
+        # traverse the computational graph to get only the random variables
+        ancestor_nodes = ancestors([data_tensor])
+        apply_nodes = [node for node in ancestor_nodes if isinstance(node, TensorVariable) and node.owner is not None]
+        rv_nodes = [node for node in apply_nodes if isinstance(node.owner.op, RandomVariable)]
+
+        # Check the total number of RVs (1 per data point)
+        expected_rv_count = np.prod(input_dataframe_all_observed.shape)
+        assert len(rv_nodes) == expected_rv_count, f"Expected {expected_rv_count} RVs, found {len(rv_nodes)}"
+
+        # Check the RV type, name, mu, and sigma
+        for idx, rv_node in enumerate(rv_nodes):
+            # Get the expected row name (index) and column name
+            row_idx, col_idx = np.unravel_index(idx, input_dataframe_all_observed.shape)
+            row_name = input_dataframe_all_observed.index[row_idx]
+            col_name = input_dataframe_all_observed.columns[col_idx]
+
+            # get the expected name, mean (mu), and stdev (sigma)
+            expected_rv_type = 'normal'
+            expected_name = f"{input_string}_{row_name}_{col_name}"
+            expected_mu = input_dataframe_all_observed.iloc[row_idx, col_idx]
+            expected_sigma = input_stdev_dataframe_all_observed.iloc[row_idx, col_idx]
+
+            # check random variable distribute type, name, mean, and stdev
+            assert rv_node.owner.op.name == expected_rv_type, f"RV is not a normal distribution: {rv_node.owner.op.name}"
+            assert rv_node.name == expected_name, f"RV name mismatch: expected {expected_name}, got {rv_node.name}"
+            assert np.isclose(rv_node.owner.inputs[3].eval(), expected_mu), f"RV mu mismatch: expected {expected_mu}, got {rv_node.owner.inputs[3].eval()}"
+            assert np.isclose(rv_node.owner.inputs[4].eval(), expected_sigma), f"RV sigma mismatch: expected {expected_sigma}, got {rv_node.owner.inputs[4].eval()}"
+
+    # Test case 2: all model variables are unobserved for all conditions
+    # unobserved data should be np.inf, and normal distrubition / stdev isn't used
+    input_dict_no_observed = {
+        'x': [np.inf, np.inf, np.inf],
+        'y': [np.inf, np.inf, np.inf]
+    }
+    input_dataframe_no_observed = pd.DataFrame(input_dict_no_observed)
+    input_stdev_dict_no_observed = {
+        'x': [np.nan, np.nan, np.nan],
+        'y': [np.nan, np.nan, np.nan]
+    }
+    input_stdev_dataframe_no_observed = pd.DataFrame(input_stdev_dict_no_observed)
 
     test_model = pm.Model()
     with test_model:
+        data_tensor = create_pytensor_from_data(input_string,input_dataframe_no_observed,input_stdev_dataframe_no_observed, input_laplace_dataframe_no_observed)
         
-        # check if actual returned value matches expected value 
-        # case 1: all data is observed across all conditions
-        # expect a normal distribution to be returned
-            rv_tensor = create_pytensor_from_data(input_string,input_dataframe_all_observed)
+        # traverse the computational graph to get only the random variables
+        ancestor_nodes = ancestors([data_tensor])
+        apply_nodes = [node for node in ancestor_nodes if isinstance(node, TensorVariable) and node.owner is not None]
+        rv_nodes = [node for node in apply_nodes if isinstance(node.owner.op, RandomVariable)]
+
+        # Check the total number of RVs (1 per data point)
+        expected_rv_count = np.prod(input_dataframe_no_observed.shape)
+        assert len(rv_nodes) == expected_rv_count, f"Expected {expected_rv_count} RVs, found {len(rv_nodes)}"
+
+        # Check the RV type, name, mu, and sigma
+        for idx, rv_node in enumerate(rv_nodes):
+            # Get the expected row name (index) and column name
+            row_idx, col_idx = np.unravel_index(idx, input_dataframe_no_observed.shape)
+            row_name = input_dataframe_no_observed.index[row_idx]
+            col_name = input_dataframe_no_observed.columns[col_idx]
+
+            # get the expected name, location (laplace mu), and scale (laplace b)
+            expected_rv_type = 'laplace'
+            expected_name = f"{input_string}_{row_name}_{col_name}"
+            expected_loc = input_laplace_dataframe_no_observed.iloc[row_idx, col_idx][0]
+            expected_scale = input_laplace_dataframe_no_observed.iloc[row_idx, col_idx][1]
+
+            # check random variable distribute type, name, location, and scale
+            assert rv_node.owner.op.name == expected_rv_type, f"RV is not a Laplace distribution: {rv_node.owner.op.name}"
+            assert rv_node.name == expected_name, f"RV name mismatch: expected {expected_name}, got {rv_node.name}"
+            assert np.isclose(rv_node.owner.inputs[3].eval(), expected_loc), f"RV loc mismatch: expected {expected_mu}, got {rv_node.owner.inputs[3].eval()}"
+            assert np.isclose(rv_node.owner.inputs[4].eval(), expected_scale), f"RV scale mismatch: expected {expected_sigma}, got {rv_node.owner.inputs[4].eval()}"
         
 
-    #     # check if returned value is a pytensor
-    #     assert(type(create_pytensor_from_data(input_string,input_dataframe_mixed))==pytensor.tensor.TensorType)
+    # Test case 3: all model variables are excluded for all conditions
+    # All data should be np.nan with Normal and Laplace distributions not used
+    # input_data_dict_all_excluded = {
+    #     'x': [np.nan, np.nan, np.nan],
+    #     'y': [np.nan, np.nan, np.nan]
+    # }
+    # input_dataframe_all_excluded = pd.DataFrame(input_data_dict_all_excluded)
     
 
-    
-    # check rows and columns
-
-    # check if value error is raised if 
-    #input_data_values = 1
-    #raise NotImplementedError
+        # # test case 4: variables are a mixture of observed, unobserved, and excluded for all conditions
+    # input_data_dict_mixed = {
+    #     'x': [1.0, np.inf, np.nan],
+    #     'y': [np.inf, np.nan, 2]
+    # }
+    # input_dataframe_mixed = pd.DataFrame(input_data_dict_mixed)
+    # input_stdev_dict_mixed = {
+    #     'x': [0.25, np.nan, np.nan],
+    #     'y': [np.nan, np.nan, 4]
+    # }
+    # input_stdev_dataframe_mixed = pd.DataFrame(input_stdev_dict_mixed)


### PR DESCRIPTION
adds a function (plus tests) to create a pytensor from missing data . 

the inputs are: 
1. name for the random variables (RVs)
2. dataset which includes values all model variables across all conditions. The dataframe should contain floats/ints for observed data, np.inf for unobserved data, and np.nan for variables which should be excluded from the model (i.e. exchange reactions). N rows for each experimental condition x M columns for each model variable
3. dataframe for standard deviations - should have same shape as the above dataset
4. dataframe for laplace parameters - values are a tuple (location, scale) for the laplace distribution, should have same shape as the above dataset

If a model variable at a particular condition was observed, then a pymc Normal distribution is created with a unique name, the observed value as the mean and the corresponding value from the input standard deviations dataframe. 

If a model variable at a particular condition was not observed, then a pymc Laplace distribution is created with a unique name, and the corresponding laplace parameter values from the input laplace parameter dataframe

If a model variable at a particular condition should be excluded from calculations, then a zero pytensor is created. 

The current implementation loops through each row and column and assigns the corresponding RV or zero tensor and then stacks them together. 

The stacked tensor is returned at the end. 

The tests cover different input data type errors, and 4 conditions: 
1. data is observed for all variables and conditions
2. data is not observed for all variables and conditions
3. all variables should be excluded
4. the data contains a mixture of observations, no observations, and exclusions (realistic case)